### PR TITLE
set the keyType in the session model to string.

### DIFF
--- a/src/Active/Active.php
+++ b/src/Active/Active.php
@@ -19,6 +19,13 @@ class Active extends Model
      * @var string
      */
     protected $primaryKey = 'id';
+    
+    /**
+     * sessions do not use incremental ids, but unique strings as identifier.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
 
     /**
      * There are no timestamps.


### PR DESCRIPTION
First of all thanks for this simple yet great package.

However I was pulling my hair out the last two days on why I cannot properly retrieve the session id from the models.

By default, Laravel casts all primaryKey fields to int, which destroys the actual session id that is a string. Instead, the model needs `protected $keyType = 'string'`

I committed the necessary line.